### PR TITLE
No longer suggesting sudo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ using custom firmware. Everything you do with this is at your own risk!
 
 To install `op1repacker` run the following command:
 
-    sudo pip3 install op1repacker
+    pip3 install --user op1repacker
 
 And to upgrade to a new version:
 
-    sudo pip3 install op1repacker --upgrade
+    pip3 install --user --upgrade op1repacker 
 
 
 ## Usage


### PR DESCRIPTION
Users should usually not run pip as sudo.

- It will not work on Windows
- It is potentially dangerous
- It will mess with the os package manager (like apt)

I suggest to, instead, change the docs to `--user`.
Keep up the good work! Appreciate your awesome project.